### PR TITLE
Updated Error object hierarchy so all error inherit from AvroError.

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,54 +1,44 @@
 var util = require('util');
 
-var AvroIOError = function() {
+var AvroError = function(name) {
     Error.call(this);
-    this.name = 'Avro IO Error';
+    this.name = name;
     this.message = util.format.apply(null, arguments);
     Error.captureStackTrace(this, arguments.callee);
+};
+
+var AvroIOError = function() {
+    AvroError.call(this, 'Avro IO Error');
 };
 
 var AvroFileError = function() {
-    Error.call(this);
-    this.name = 'Avro File Error';
-    this.message = util.format.apply(null, arguments);
-    Error.captureStackTrace(this, arguments.callee);
+    AvroError.call(this, 'Avro File Error');
 };
 
 var AvroBlockError = function() {
-    Error.call(this);
-    this.name = 'Avro Block Error';
-    this.message = util.format.apply(null, arguments);
-    Error.captureStackTrace(this, arguments.callee);
+    AvroError.call(this, 'Avro Block Error');
 };
 
 var AvroBlockDelayReadError = function() {
-    Error.call(this);
-    this.name = 'Avro Block Delay Read Error';
-    this.message = util.format.apply(null, arguments);
-    Error.captureStackTrace(this, arguments.callee);
+    AvroError.call(this, 'Avro Block Delay Read Error');
 };
 
 var AvroInvalidSchemaError = function() {
-    Error.call(this);
-    this.name = 'Avro Invalid Schema Error';
-    this.message = util.format.apply(null, arguments);
-    Error.captureStackTrace(this, arguments.callee);
+    AvroError.call(this, 'Avro Invalid Schema Error');
 };
 
 var AvroDataValidationError = function() {
-    Error.call(this);
-    this.name = 'Avro Data Validation Error';
-    this.message = util.format.apply(null, arguments);
+    AvroError.call(this, 'Avro Data Validation Error');
     this.fieldPath = [];
-    Error.captureStackTrace(this, arguments.callee);
 };
 
-util.inherits(AvroIOError, Error);
-util.inherits(AvroFileError, Error);
-util.inherits(AvroBlockError, Error);
-util.inherits(AvroBlockDelayReadError, Error);
-util.inherits(AvroInvalidSchemaError, Error);
-util.inherits(AvroDataValidationError, Error);
+util.inherits(AvroError, Error);
+util.inherits(AvroIOError, AvroError);
+util.inherits(AvroFileError, AvroError);
+util.inherits(AvroBlockError, AvroError);
+util.inherits(AvroBlockDelayReadError, AvroError);
+util.inherits(AvroInvalidSchemaError, AvroError);
+util.inherits(AvroDataValidationError, AvroError);
 
 exports.IOError = AvroIOError;
 exports.FileError = AvroFileError;


### PR DESCRIPTION
- lib/errors.js
  
  Cleaned up the various Avro...Error classes so they inherit from
  a single AvroError class that contains the common code.  Removed
  duplicated code from the various implementation classes.
