### PR TITLE
Completed code review and clean up of the Block class.

### DIFF
--- a/lib/datafile.js
+++ b/lib/datafile.js
@@ -148,21 +148,29 @@ _.extend(Block.prototype, {
     },
 
     _canReUseBuffer: function(size) {
-        return this.reUseBuffer && this._readOffset >= size;
+        return this.reUseBuffer && (this._buffer.length - this.remainingBytes) >= size;
     },
 
     _resizeIfRequired: function(size) {
         if (this._canReUseBuffer(size)) {
-            if (this._readOffset != this._writeOffset)
+            if (this._readOffset > 0 && this._readOffset != this._writeOffset) {
                 this._buffer.copy(this._buffer, 0, this._readOffset, this._writeOffset);
-            this._writeOffset = this.remainingBytes;
-            this._readOffset = 0;
-        } else if (this._writeOffset + size > this._buffer.length) {
+            }
+        } else {
             var oldBuffer = this._buffer;
-            this._buffer = new Buffer(this._bufferSize(size));
-            oldBuffer.copy(this._buffer, 0);
+
+            if (this.remainingBytes + size > this._buffer.length) {
+                this._buffer = new Buffer(this._bufferSize(size));
+            } else { // reUseBuffer is false
+                this._buffer = new Buffer(this._buffer.length);
+            }
+
+            oldBuffer.copy(this._buffer, 0, this._readOffset, this._writeOffset);
             oldBuffer = null;
         }
+
+        this._writeOffset = this.remainingBytes;
+        this._readOffset = 0;
     },
 
     skip: function(size) {
@@ -175,7 +183,7 @@ _.extend(Block.prototype, {
     read: function(size) {
         var self = this;
         if (size > this.remainingBytes) {
-            return new AvroErrors.BlockDelayReadError('tried to read %d bytes past the amount written to the block with remaining bytes %d at read offset %d',
+            throw new AvroErrors.BlockDelayReadError('tried to read %d bytes past the amount written to the block with remaining bytes %d at read offset %d',
                                       size, this.remainingBytes, this._readOffset);
         } else if (this._readOffset + size > this._buffer.length) {
             throw new AvroErrors.BlockError('tried to read %d bytes outside of the buffer(%d) at read offset %d',
@@ -190,7 +198,7 @@ _.extend(Block.prototype, {
         }
     },
 
-    // write() supports an array of numbers of a Buffer
+    // write() supports an array of numbers or a Buffer
     write: function(value) {
         var len = (Buffer.isBuffer(value) || _.isArray(value)) ? value.length : 1;
         this._resizeIfRequired(len);


### PR DESCRIPTION
- lib/datafile.js
  
  Changed _canReUseBuffer to properly reflect whether the amount of free space
  remaining is at least `size` bytes.
  
  In _resizeRequired, no longer execute a copy of the buffer contents if the
  readOffset is already 0.  Further modified this function to handle the case
  where reUseBuffer is false, in which case we create a new buffer of the same
  size as the existing buffer and copy over the bytes between readOffset and
  writeOffset.
  
  Changed read to throw AvroErrors.BlockDelayReadError rather than returning
  this object.
- test/datafile.test.js
  
  Implemented test suites for _bufferSize, _canReUseBuffer, _resizeIfRequired,
  read, and isEqual.  Added additional tests for other test suites to cover
  cases not yet captured and did some miscellaneous clean up of the tests.
