### PR TITLE
Updated Long.readLong to return an instance of Long rather than a number

### DIFF
--- a/lib/io.js
+++ b/lib/io.js
@@ -44,7 +44,7 @@ BinaryDecoder.prototype = {
     },
 
     readInt: function () {
-        return this.readLong();
+        return this.readLong().toNumber();
     },
 
     readLong: function () {
@@ -73,7 +73,7 @@ BinaryDecoder.prototype = {
             shift += 7;
         }
 
-        return (n.shiftRightUnsigned(1)).xor(-(n.and(1))).toNumber();
+        return (n.shiftRightUnsigned(1)).xor(-(n.and(1)));
     },
 
     readFloat: function() {
@@ -103,8 +103,8 @@ BinaryDecoder.prototype = {
         var oldOffset = this._input.offset;
         var len = this.readLong();
         //console.error("I want to read %d bytes, from %d (%d)", len, oldOffset, this._input.length);
-        if (len && len > 0) {
-            var bytes = this.readFixed(len);
+        if (len && len.isPositive()) {
+            var bytes = this.readFixed(len.toNumber());
             if (bytes instanceof AvroErrors.BlockDelayReadError)
                 this._input.skip(oldOffset - this._input.offset);
             return bytes;
@@ -149,7 +149,7 @@ BinaryDecoder.prototype = {
     },
 
     skipBytes: function() {
-        var len = this.readLong();
+        var len = this.readLong().toNumber();
         this._input.skip(len);
     },
 
@@ -195,13 +195,8 @@ BinaryEncoder.prototype = {
     },
 
     writeLong: function(value) {
-        var n;
+        var n = Long.fromValue(value);
         var self = this;
-
-        if (value instanceof Long)
-            n = value;
-        else
-            n = Long.fromNumber(value);
 
         function wb(byte){
             self.writeByte(byte);
@@ -392,9 +387,10 @@ DatumReader.prototype = {
         var oldOffset = decoder._input.offset;
         var schemaIndex = decoder.readLong();
         if (schemaIndex instanceof AvroErrors.BlockDelayReadError) return schemaIndex;
-        if (schemaIndex < 0 || schemaIndex >= writersSchema.schemas.length) {
-            throw new AvroErrors.IOError("Union %j is out of bounds for %d, %d, %d", writersSchema, schemaIndex, decoder._input.offset, decoder._input.length);
+        if (schemaIndex.isNegative() || schemaIndex.greaterThanOrEqual(writersSchema.schemas.length)) {
+            throw new AvroErrors.IOError("Union %j is out of bounds for %d, %d, %d", writersSchema, schemaIndex.toNumber(), decoder._input.offset, decoder._input.length);
         }
+        schemaIndex = schemaIndex.toNumber();
         var selectedWritersSchema = writersSchema.schemas[schemaIndex];
         var union = {};
         var data = this.readData(selectedWritersSchema, readersSchema.schemas[schemaIndex], decoder);
@@ -412,7 +408,7 @@ DatumReader.prototype = {
         if (index === null)
             return null
         else
-            return this.skipData(writersSchema.schemas[index], decoder)
+            return this.skipData(writersSchema.schemas[index.toNumber()], decoder)
     },
 
     readRecord: function(writersSchema, readersSchema, decoder) {
@@ -448,7 +444,8 @@ DatumReader.prototype = {
         var oldOffset = decoder._input.offset;
         var count = decoder.readLong();
         if (count instanceof AvroErrors.BlockDelayReadError) return count;
-        while(count) {
+        while(!count.isZero()) {
+            count = count.toNumber();
             if (count < 0) {
                 count = -count;
                 var output = iteration();
@@ -467,11 +464,11 @@ DatumReader.prototype = {
     },
 
     readBlocks: function(decoder, lambda) {
-        return this._iterateBlocks(decoder, function() { return decoder.readLong(); }, lambda);
+        return this._iterateBlocks(decoder, function() { return decoder.readLong().toNumber(); }, lambda);
     },
 
     skipBlocks: function(decoder, lambda) {
-        return this._iterateBlocks(decoder, function() { decoder.skipFixed(decoder.readLong()) }, lambda);
+        return this._iterateBlocks(decoder, function() { decoder.skipFixed(decoder.readLong().toNumber()) }, lambda);
     }
 }
 

--- a/lib/io.js
+++ b/lib/io.js
@@ -58,9 +58,8 @@ BinaryDecoder.prototype = {
 
         var n = b.and(L_0x7f);
         var shift = 7;
-        var numShifts = 0;
 
-        while (b.greaterThan(L_0x7f) && numShifts < 7) {
+        while (b.greaterThan(L_0x7f)) {
             b = this.readByte();
             if (b instanceof AvroErrors.BlockDelayReadError) {
                 //console.error("offset now is %d, old was %d, shift is %d", this._input.offset, oldOffset, shift);
@@ -72,7 +71,6 @@ BinaryDecoder.prototype = {
             n = n.xor(b.and(L_0x7f).shiftLeft(shift));
 
             shift += 7;
-            numShifts++;
         }
 
         return (n.shiftRightUnsigned(1)).xor(-(n.and(1))).toNumber();
@@ -121,7 +119,7 @@ BinaryDecoder.prototype = {
         else {
             if (Buffer.isBuffer(bytes))
                 return bytes.toString();
-            else 
+            else
                 return String.fromCharCode(bytes);
         }
     },
@@ -197,8 +195,13 @@ BinaryEncoder.prototype = {
     },
 
     writeLong: function(value) {
-        var n = Long.fromNumber(value);
+        var n;
         var self = this;
+
+        if (value instanceof Long)
+            n = value;
+        else
+            n = Long.fromNumber(value);
 
         function wb(byte){
             self.writeByte(byte);
@@ -213,11 +216,9 @@ BinaryEncoder.prototype = {
         if (n.and(L_0x7f.not()).toNumber() !== 0) {
             wb(n.or(L_0x80).and(L_0xFF).getLowBits());
             n = n.shiftRightUnsigned(7);
-            var numShifts = 0;
-            while (n.greaterThan(L_0x7f) && numShifts < 8) {
+            while (n.greaterThan(L_0x7f)) {
                 wb(n.or(L_0x80).and(L_0xFF).getLowBits());
                 n = n.shiftRightUnsigned(7);
-                numShifts++;
             }
         }
         wb(n.and(L_0xFF).getLowBits());


### PR DESCRIPTION
This change enables handling of true 64-bit data.  Note, however, that when a long is used internally for a size, it is converted to a JavaScript number.  The assumption I'm making is that we're generally not going to have data blobs to read from a file that exceed 2^53-1 bytes.
