### PR TITLE
Updated Reader to properly handle when fileBlock needs more data.

### DIFF
--- a/lib/datafile.js
+++ b/lib/datafile.js
@@ -356,13 +356,25 @@ _.extend(Reader.prototype, {
 
     _readBlocks: function(cb) {
         var self = this;
-        self._readBlock(function(err) {
-            if (err || self._fileBlock.remainingBytes === 0) {
+
+        try {
+            var readOffset = this._fileBlock.offset;
+
+            self._readBlock(function(err) {
+                if (err || self._fileBlock.remainingBytes === 0) {
+                    cb();
+                } else {
+                    self._readBlocks(cb);
+                }
+            });
+        } catch (e) {
+            if (e instanceof AvroErrors.BlockDelayReadError) {
+                this._fileBlock._readOffset = readOffset;
                 cb();
             } else {
-                self._readBlocks(cb);
+                throw e;
             }
-        });
+        }
     },
 
     _transform: function(chunk, encoding, done) {

--- a/lib/datafile.js
+++ b/lib/datafile.js
@@ -362,7 +362,7 @@ _.extend(Reader.prototype, {
 
             self._readBlock(function(err) {
                 if (err || self._fileBlock.remainingBytes === 0) {
-                    cb();
+                    cb(err);
                 } else {
                     self._readBlocks(cb);
                 }

--- a/lib/io.js
+++ b/lib/io.js
@@ -85,7 +85,7 @@ BinaryDecoder.prototype = {
         var oldOffset = this._input.offset;
         var len = this.readLong();
         //console.error("I want to read %d bytes, from %d (%d)", len, oldOffset, this._input.length);
-        if (len && len.isPositive()) {
+        if (len && len.greaterThan(0)) {
             var bytes = this.readFixed(len.toNumber());
             return bytes;
         } else


### PR DESCRIPTION
- lib/datafile.js
  
  Updated Reader._readBlocks to enclose the invocation of _readBlock within a
  try...catch block.  BlockDelayReadError being thrown indicates that the file
  block does not have enough data for the read yet.  We reset the read pointer
  back to the beginning of the block and wait for _transform to be invoked
  again, feeding us more data.
- lib/io.js
  
  Modified readBytes to use Long.greaterThan(0) rather than isPositive.
  isPositive is sporadically not working correctly, dumping lots of warnings
  about recursive invocation of process.nextTick.
