### PR TITLE
upgrade snappy to ^4.1.2 for node 4 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "underscore": "^1.7.0",
-    "snappy": "^2.1.1",
+    "snappy": "^4.1.2",
     "buffer-crc32": "^0.2.5",
     "long": "git@github.com:blake-nicholson/Long.js.git#fix_greaterThanOrEqual"
   },


### PR DESCRIPTION
- package.json

upgrade snappy to ^4.1.2 for node 4 support

see https://github.com/kesla/node-snappy/issues/66
